### PR TITLE
Fix intersection observer loop

### DIFF
--- a/src/components/IntersectionAnimator.tsx
+++ b/src/components/IntersectionAnimator.tsx
@@ -1,30 +1,33 @@
 import { useInView } from "react-intersection-observer"
-import { SpringConfig } from "react-spring";
-import { useSpring, animated } from "react-spring";
-import { anims } from "../utils/springs"; 
+import { SpringConfig } from "react-spring"
+import { useSpring, animated } from "react-spring"
+import { Animation } from "../utils/springs"
 
-type Animation = typeof anims[keyof typeof anims];
+export function IntersectionAnimator (props: IntersectionAnimatorProps) {
+  const { threshold = 1, innerProps = {} }  = props
+  const [animationWrapper, isWrapperInView] = useInView ({ threshold })
+  const animation = useSpring ({
+    ...(isWrapperInView ? props.inViewAnimation : props.notInViewAnimation),
+    config: props.config,
+  })
+
+  return (
+    <div className="animationWrapper" ref={animationWrapper}>
+      <animated.div {...innerProps} style={animation} >
+        {props.children}
+      </animated.div>
+    </div>
+  )
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 type IntersectionAnimatorProps = {
-    children: React.ReactNode;
-    threshold?: number,
-    inViewAnimation:  Animation,
-    notInViewAnimation: Animation,
-    config?: SpringConfig | ((key: string) => SpringConfig),
-    innerProps?: React.HTMLAttributes<HTMLDivElement>
+  children: React.ReactNode,
+  threshold?: number,
+  inViewAnimation: Animation,
+  notInViewAnimation: Animation,
+  config?: SpringConfig | ((key: string) => SpringConfig),
+  innerProps?: React.HTMLAttributes<HTMLDivElement>
 }
 
-export const IntersectionAnimator = (props: IntersectionAnimatorProps) => {
-    const { threshold = 1, innerProps = {} } = props;
-    const [animationWrapper, isAnimationWrapperInView] = useInView ({ threshold });
-    const animation = useSpring ({
-        ...(isAnimationWrapperInView ? props.inViewAnimation : props.notInViewAnimation),
-        config: props.config,
-    });
-
-    return <div className="animationWrapper" ref={animationWrapper}>
-        <animated.div {...innerProps} style={animation} >
-            {props.children}
-        </animated.div>
-    </div>
-}

--- a/src/components/IntersectionAnimator.tsx
+++ b/src/components/IntersectionAnimator.tsx
@@ -1,0 +1,30 @@
+import { useInView } from "react-intersection-observer"
+import { SpringConfig } from "react-spring";
+import { useSpring, animated } from "react-spring";
+import { anims } from "../utils/springs"; 
+
+type Animation = typeof anims[keyof typeof anims];
+
+type IntersectionAnimatorProps = {
+    children: React.ReactNode;
+    threshold?: number,
+    inViewAnimation:  Animation,
+    notInViewAnimation: Animation,
+    config?: SpringConfig | ((key: string) => SpringConfig),
+    innerProps?: React.HTMLAttributes<HTMLDivElement>
+}
+
+export const IntersectionAnimator = (props: IntersectionAnimatorProps) => {
+    const { threshold = 1, innerProps = {} } = props;
+    const [animationWrapper, isAnimationWrapperInView] = useInView ({ threshold });
+    const animation = useSpring ({
+        ...(isAnimationWrapperInView ? props.inViewAnimation : props.notInViewAnimation),
+        config: props.config,
+    });
+
+    return <div className="animationWrapper" ref={animationWrapper}>
+        <animated.div {...innerProps} style={animation} >
+            {props.children}
+        </animated.div>
+    </div>
+}

--- a/src/sections/9_credits.tsx
+++ b/src/sections/9_credits.tsx
@@ -1,21 +1,21 @@
 import { Contributor, credits } from '../data/credits'
 import '../styles/9_credits.scss'
 import '../images/coco_looking_at_horizon.png'
-import { useInView } from 'react-intersection-observer'
-import { useSpring, animated } from 'react-spring'
 import { configs, anims } from 'utils/springs'
+import { IntersectionAnimator } from 'components/IntersectionAnimator'
 
 export function Credits () {
-  const [title, inViewTitle] = useInView ({ threshold: 1 })
-  const slideUpTitle = useSpring ({
-    ...(inViewTitle ? anims.fadeInSlideUp : anims.fadeOutSlideDown),
-    config: configs.shortEaseOut
-  })
-
   return (<>
-    <animated.div id="credits-title" ref={title} style={slideUpTitle}>
+    <IntersectionAnimator
+      threshold={1}
+      inViewAnimation={anims.fadeInSlideUp}
+      notInViewAnimation={anims.fadeOutSlideDown}
+      config={configs.shortEaseOut}
+      innerProps={{id: 'credits-title'}}
+    >
       Credits
-    </animated.div>
+    </IntersectionAnimator>
+    
 
     <div id="credits">
       {credits.map ((cont, cat) => <Credit category={cat} content={cont} />)
@@ -34,17 +34,13 @@ interface CreditProps {
 }
 
 function Credit ({category, content}: CreditProps) {
-  const [ref, inView] = useInView ({ threshold: .4 })
-  const slideUpCredits = useSpring ({
-    ...(inView ? anims.fadeInSlideUp : anims.fadeOutSlideDown),
-    config: configs.shortEaseOut
-  })
-
   return (
-    <animated.div
-      className="credit-block"
-      ref={ref}
-      style={slideUpCredits}
+    <IntersectionAnimator
+      threshold={.4}
+      inViewAnimation={anims.fadeInSlideUp}
+      notInViewAnimation={anims.fadeOutSlideDown}
+      config={configs.shortEaseOut}
+      innerProps={{className: 'credit-block'}}
     >
       <div className="credit-category">{category}</div>
 
@@ -78,6 +74,6 @@ function Credit ({category, content}: CreditProps) {
         </div>
       ))}
 
-    </animated.div>
+  </IntersectionAnimator>
   )
 }

--- a/src/sections/9_credits.tsx
+++ b/src/sections/9_credits.tsx
@@ -18,8 +18,9 @@ export function Credits () {
     
 
     <div id="credits">
-      {credits.map ((cont, cat) => <Credit category={cat} content={cont} />)
-              .toList ()}
+      {credits
+        .map ((cont, cat) => <Credit category={cat} content={cont} />)
+        .toList ()}
     </div>
 
     <div id="coco-looking-at-horizon"></div>
@@ -73,7 +74,6 @@ function Credit ({category, content}: CreditProps) {
             : ''}
         </div>
       ))}
-
   </IntersectionAnimator>
   )
 }

--- a/src/utils/springs.ts
+++ b/src/utils/springs.ts
@@ -24,6 +24,8 @@ export const anims = {
   fadeOutSlideDown: { to: { opacity: 0, transform: "translateY(50px)" } },
 }
 
+export type Animation = typeof anims[keyof typeof anims]
+
 ///////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
Fixing an observer issue on the credit page. 

Issue: attaching a visibility observer to an animating element causes it to loop in and out of visibility

Solution: attach visibility observer to a wrapper wrapping the animated component. Also for overkill, made this pattern a component so we don't have to keep rewriting this pattern