### PR TITLE
Bugfix for gradient for iOS Mobile Browsers

### DIFF
--- a/src/styles/Credits.scss
+++ b/src/styles/Credits.scss
@@ -25,6 +25,8 @@
     padding-top: 86px;
     margin-top: -20px;
     span {
+      background: -webkit-linear-gradient(45deg, $dark1, $med1);
+      -webkit-background-clip: text;
       margin-left: 15px;
     }
     img {

--- a/src/styles/Messages.scss
+++ b/src/styles/Messages.scss
@@ -63,6 +63,11 @@
       font-size: 26px;
     }
     span {
+      background: -webkit-linear-gradient(45deg, $dark1, $med1);
+      -webkit-background-clip: text;
+      //Other fix, delete if no longer needed
+      //@include gradient-title;
+      //font-size: 46px;
       margin-left: 30px;
     }
     img {

--- a/src/styles/Playlist.scss
+++ b/src/styles/Playlist.scss
@@ -27,6 +27,8 @@
     font-size: 36px;
   }
   span {
+    background: -webkit-linear-gradient(45deg, $dark1, $med1);
+    -webkit-background-clip: text;
     margin-left: 30px;
   }
   img {
@@ -56,4 +58,3 @@
     position: absolute;
   }
 }
-


### PR DESCRIPTION
In iOS (unsure for android phones) the gradient doesn't appear properly due to a possible bug from iOS' webkit itself. Specifically, applying CSS on parent elements, particularly the gradient and/or background-clip, doesnt translate well for child elements; with the supposed fix having to attach `display: inline` into the specific element and/or it should be working in the first place.

The fix doesn't work, with the only _elegant_ solutions working is either not using `display: flex` for parent elements and using `display: inline` instead, or using the element on its own (outside of a parent element).

Out of all the solutions I've tried, there's only two that seems elegant enough to not break for other browsers and show the text as intended for iOS which can be seen on this pull request. It basically re-implements the gradient and the background-clip to the `span` element which somehow makes it work. Considering the other solutions, this is possibly the most proper fix for this issue.

The other mentioned fix can be seen on `Messages.scss` though besides moving the `@include gradient-title` line from its parent, it makes the text seem larger on mobile.

This bug can currently be seen on Safari and Firefox for iOS, and has probably been fixed. Other browsers hasn't been tested yet, but assumed it should work.