### PR TITLE
doing really simple prop style optimisations

### DIFF
--- a/src/components/AssetLoader.tsx
+++ b/src/components/AssetLoader.tsx
@@ -20,7 +20,7 @@ export function AssetLoader (props: AssetLoaderProps)  {
       href={href}
       as={as}
       key={href}
-      onLoad={ () => setLoads (prevState => ({ ...prevState, [href]: true,  }))}
+      onLoad={() => setLoads (prevState => ({ ...prevState, [href]: true,  }))}
       onError={() => setLoads (prevState => ({ ...prevState, [href]: false, }))}
     />)
 

--- a/src/components/Credits.tsx
+++ b/src/components/Credits.tsx
@@ -5,18 +5,22 @@ import { FadeInSlideUp } from 'components/IntersectionAnimator'
 // import dragonTail from 'images/dragon_tail.png'
 import combinedEmoji from 'images/message_images/combined_emoji.png'
 
+const creditList = credits
+  .map ((cont, cat) => <Credit key={cat} category={cat} content={cont} />)
+  .toList ();
+
+const innerCreditProps = { id: 'credits-title' };
+
 export function Credits () {
   return (
   <div id="credit-wrapper">
-    <FadeInSlideUp threshold={.8} innerProps={{id: 'credits-title'}} >
+    <FadeInSlideUp threshold={.8} innerProps={innerCreditProps} >
       <img src={combinedEmoji} alt="" />
       <span>Credits</span>
     </FadeInSlideUp>
     
     <div id="credits">
-      {credits
-        .map ((cont, cat) => <Credit key={cat} category={cat} content={cont} />)
-        .toList ()}
+      {creditList}
     </div>
 
     <div id="coco-looking-at-horizon"></div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,14 +6,19 @@ import { configs, anims } from 'utils/springs'
 import { Parallax } from 'react-scroll-parallax'
 import kanataLookingAtDragon from 'images/kanata_looking_at_dragon.png'
 
+const getTextAnim = (prop: 'right'|'left', inView: boolean) => ({
+  ...(inView ? { from: { [prop]: '55%' }, to: { [prop]: '50%'  } }
+             : { from: { [prop]: '50%' }, to: { [prop]: '40%' } }),
+  config: configs.longEaseOut
+})
+
+const parallaxValues = [-75, 60];
+
 export function Header () {
   const [ref, inView] = useInView ({ threshold: .95, initialInView: true })
+  const topTextStyle = useSpring (getTextAnim ('left', inView));
+  const bottomTextStyle = useSpring (getTextAnim ('right', inView));
 
-  const getTextAnim = (prop: 'right'|'left') => ({
-    ...(inView ? { from: { [prop]: '55%' }, to: { [prop]: '50%'  } }
-               : { from: { [prop]: '50%' }, to: { [prop]: '40%' } }),
-    config: configs.longEaseOut
-  })
 
   const fade = useSpring ({
     ...(inView ? anims.fadeIn : anims.fadeOut),
@@ -22,7 +27,7 @@ export function Header () {
 
   return (<>
     <div id="header" ref={ref}>
-    <Parallax className="header-bg" y={[-75, 60]} >
+    <Parallax className="header-bg" y={parallaxValues} >
       <animated.div id="dark-overlay" style={fade}></animated.div>
       <img src={kanataLookingAtDragon} alt="" />
     </Parallax>
@@ -36,13 +41,13 @@ export function Header () {
         <div id="header-text-container">
           <animated.div
             id="text-to-the-strongest"
-            style={useSpring (getTextAnim ('left'))}
+            style={topTextStyle}
           >
             <animated.div style={fade}>To the strongest</animated.div>
           </animated.div>
           <animated.div
             id="text-luknight"
-            style={useSpring (getTextAnim ('right'))}
+            style={bottomTextStyle}
           >
             <animated.div style={fade}>Luknight</animated.div>
           </animated.div>

--- a/src/components/IntersectionAnimator.tsx
+++ b/src/components/IntersectionAnimator.tsx
@@ -28,7 +28,7 @@ export function FadeInSlideUp (props: FadeInSlideUpProps) {
       inViewAnimation={anims.fadeInSlideUp}
       notInViewAnimation={anims.fadeOutSlideDown}
       config={configs.shortEaseOut}
-      innerProps={props.innerProps ?? {}}
+      innerProps={props.innerProps}
     >
       {props.children}
     </IntersectionAnimator>
@@ -43,7 +43,7 @@ type IntersectionAnimatorProps = {
   inViewAnimation: Animation,
   notInViewAnimation: Animation,
   config?: SpringConfig | ((key: string) => SpringConfig),
-  innerProps?: React.HTMLAttributes<HTMLDivElement>
+  innerProps?: React.HTMLAttributes<HTMLDivElement> | undefined
 }
 
 type FadeInSlideUpProps = {

--- a/src/components/IntroductionText.tsx
+++ b/src/components/IntroductionText.tsx
@@ -1,5 +1,4 @@
 import 'styles/IntroductionText.scss'
-import { FadeInSlideUp } from 'components/IntersectionAnimator'
 
 export function IntroductionText (props: { className?: string}) {
   return (

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -44,10 +44,12 @@ const allEls = [
   ...insertEveryN (6, messageEls.slice (4), imageEls)
 ]
 
+const messageInnerProps = {id: 'messages-title'};
+
 export function Messages () {
   return (
     <div id="messages">
-      <FadeInSlideUp innerProps={{id: 'messages-title'}} >
+      <FadeInSlideUp innerProps={messageInnerProps} >
         <img src={chibiYonkisei} alt="" />
         <span>Messages from Luknights</span>
       </FadeInSlideUp>

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -2,11 +2,13 @@ import 'styles/Playlist.scss'
 import { FadeInSlideUp } from 'components/IntersectionAnimator'
 import cocoDream from 'images/coco_dream.gif'
 
+const animationInnerProps = {id: 'playlist-title'};
+
 export function Playlist () {
   return (
     <div id="playlist-section">
       <div id="playlist-video-wrapper">
-        <FadeInSlideUp innerProps={{id: 'playlist-title'}} >
+        <FadeInSlideUp innerProps={animationInnerProps} >
         <img src={cocoDream} alt="" />
           <span>HimeCoco playlist</span>
         </FadeInSlideUp>


### PR DESCRIPTION
<img width="961" alt="improved render" src="https://user-images.githubusercontent.com/2517506/122679170-704ddb80-d21c-11eb-9acf-69c00e76656e.png">

Improved the main heavy render by 2ms (7ms down to 5ms).

These changes are simple and not exhaustive. If we're still having issues we could look at more structural changes (like removing the AssetLoader from the component tree when it's no longer required)